### PR TITLE
Removed unused const char *prec and fixed length of history vars.

### DIFF
--- a/args.C
+++ b/args.C
@@ -55,7 +55,6 @@ extern Double bc0;
 extern Double bc1;
 extern Double min_change;
 extern char const *runame;
-extern char const *prec;
 extern char const *ic;
 extern char const *alg;
 extern int savi;
@@ -78,7 +77,6 @@ process_args(int argc, char **argv)
         fprintf(stderr, "Usage: ./heat <arg>=<value> <arg>=<value>...\n");
 
     HANDLE_ARG(runame, char*, %s, name to give run and results dir);
-    HANDLE_ARG(prec, char*, %s, precision half|float|double|quad);
     HANDLE_ARG(alpha, double, %g, material thermal diffusivity (sq-meters/second));
     HANDLE_ARG(lenx, double, %g, material length (meters));
     HANDLE_ARG(dx, double, %g, x-incriment. Best if lenx/dx==int. (meters));

--- a/heat.C
+++ b/heat.C
@@ -13,7 +13,6 @@ int outi         = 100;
 int save         = 0;
 char const *runame = "heat_results";
 char const *alg  = "ftcs";
-char const *prec = "double";
 char const *ic   = "const(1)";
 Double lenx      = 1.0;
 Double alpha     = 0.2;
@@ -91,8 +90,8 @@ initialize(void)
     if (save)
     {
         exact = new Double[Nx]();
-        change_history = new Double[Nx]();
-        error_history = new Double[Nx]();
+        change_history = new Double[Nt]();
+        error_history = new Double[Nt]();
     }
 
     assert(strncmp(alg, "ftcs", 4)==0 ||
@@ -117,8 +116,8 @@ int finalize(int ti, Double maxt, Double change)
     write_array(TFINAL, Nx, dx, curr);
     if (save)
     {
-        write_array(RESIDUAL, ti, dt, change_history);
-        write_array(ERROR, ti, dt, error_history);
+        write_array(RESIDUAL, ti < Nt ? ti : Nt, dt, change_history);
+        write_array(ERROR, ti < Nt ? ti : Nt, dt, error_history);
     }
 
     if (outi)
@@ -134,7 +133,6 @@ int finalize(int ti, Double maxt, Double change)
     if (error_history) delete [] error_history;
     if (cn_Amat) delete [] cn_Amat;
     if (strncmp(alg, "ftcs", 4)) free((void*)alg);
-    if (strncmp(prec, "double", 6)) free((void*)prec);
     if (strncmp(ic, "const(1)", 8)) free((void*)ic);
 
     return retval;
@@ -168,7 +166,7 @@ update_output_files(int ti)
         write_array(ti, Nx, dx, curr);
 
     change = l2_norm(Nx, curr, last);
-    if (save)
+    if (save && ti < Nt)
     {
         change_history[ti] = change;
         error_history[ti] = l2_norm(Nx, curr, exact);


### PR DESCRIPTION
This fixes an array size bug.  The prec variable was meant to represent precision, but not implemented.