### PR TITLE
Add check.yml for github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,19 @@
+name: Check Results
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make coverage
+      run: make CXXFLAGS=--coverage LDFLAGS="--coverage -lm" check_all
+    - name: upload coverage
+      run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This closes #2 and #9.  However, it will show up in `main` for any repo created from this template.  I'd rather use a regular repo. to keep this material, then use branches for "solutions" like this one.